### PR TITLE
Log non 2XX & 3XX network responses

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -141,6 +141,10 @@ export class Renderer {
     // to return a partial response for what was able to be rendered in that
     // time frame.
     page.on('response', (r: puppeteer.HTTPResponse) => {
+      if (!/^2|^3|^401$/.test(r.status().toString())) {
+        console.log('Rendertron Network Response:', r.url(), r.status());
+      }
+
       if (!response) {
         response = r;
       }


### PR DESCRIPTION
Log responses from network requests within rendertron, so we can track if there are common failures in the network responses.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/59832307/222703051-ca823892-a78b-4682-a75c-f54163ceb5aa.png">
