### PR TITLE
APE-2393: Increase Rendertron timeout

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ export class ConfigManager {
       cacheDurationMinutes: (60 * 24).toString(),
       cacheMaxEntries: '100',
     },
-    timeout: 10000,
+    timeout: 30000,
     port: '3000',
     host: '0.0.0.0',
     width: 1000,


### PR DESCRIPTION
Increase Rendertron timeout. We are intentionally keeping this separate from properly handling the timeout, as we should see an improvement with this change alone without the risk of breaking things.