### PR TITLE
link healthcheck status to render concurrency count

### DIFF
--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,36 +1,32 @@
 class SingletonCounter {
-  private static instance: SingletonCounter;
   private count: number;
   private concurrency: number;
 
   // Starting at 3 as the first actual render will be number 4
-  private constructor(initialCount = 3) {
+  public constructor(initialCount = 3) {
     this.count = initialCount;
     this.concurrency = 0;
   }
 
-  public static getInstance(): SingletonCounter {
-    if (!SingletonCounter.instance) {
-      SingletonCounter.instance = new SingletonCounter();
-    }
-    return SingletonCounter.instance;
-  }
-
-  public start(): CounterState {
+  public increase(): CounterState {
     this.count++;
     this.concurrency++;
     return { count: this.count, concurrency: this.concurrency };
   }
 
-  public end(): CounterState {
+  public decrease(): CounterState {
     this.concurrency--;
+    return { count: this.count, concurrency: this.concurrency };
+  }
+
+  public getCounts(): CounterState {
     return { count: this.count, concurrency: this.concurrency };
   }
 }
 
-interface CounterState {
+type CounterState = {
   count: number;
   concurrency: number;
 }
 
-export default SingletonCounter;
+export default new SingletonCounter() ;

--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -17,7 +17,7 @@ import counter from './counter';
 
 const marketRegex = /https:\/\/.*?\/(.*?)\//
 
-const concurrencyKillCount = Number(process.env.CONCURRENCY_KILL_COUNT) || 8;
+const concurrencyKillCount = Number(process.env.CONCURRENCY_KILL_COUNT) || 5;
 
 /**
  * Rendertron rendering service. This runs the server which routes rendering


### PR DESCRIPTION
Adds a new env variable `CONCURRENCY_KILL_COUNT` with a default of 5.

Once this number is exceeded when compared to the number of concurrent renders, the healthcheck endpoint will fail and start to return a 500.

This can then be used in conjunction with a kubernetes liveness check to then kill this pod if these limits are breached.

Sample logs from when this value is set to 1 and we run some parallel renders.

```
info: Health check passed <= 1 {"render_concurrency":0,"render_count":3}
info: GET /_ah/health 200 7ms
info: Health check passed <= 1 {"render_concurrency":0,"render_count":3}
info: GET /_ah/health 200 1ms
info: render request {"render_concurrency":1,"render_count":4,"render_crawler":"GoogleBot","render_id":"ce989ce5-e736-4d5e-9206-74302fe74e13","render_market":"en-uk","render_url":"https://www.staging.env.mpb.com/en-uk/product/canon-powershot-g9?bust=7119","render_user_agent":"GoogleBot"}
info: render request {"render_concurrency":2,"render_count":5,"render_crawler":"GoogleBot","render_id":"ce7ffd36-a626-41ea-addd-38998c46b84a","render_market":"en-us","render_url":"https://www.staging.env.mpb.com/en-us/product/zeiss-milvus-25mm-f-1-4-ze-canon-ef-fit/sku-2941122?utm_source=google&utm_medium=surfaces&utm_campaign=shopping%20feed&utm_content=free%20google%20shopping%20clicks?bust=8653","render_user_agent":"GoogleBot"}
info: render request {"render_concurrency":3,"render_count":6,"render_crawler":"GoogleBot","render_id":"886cc4a4-2ba7-4941-9801-ca0ba9752e37","render_market":"de-at","render_url":"https://www.staging.env.mpb.com/de-at/produkt/dji-dl-pz-17-28mm-t30-asph?bust=5055","render_user_agent":"GoogleBot"}
error: Health check failed > 1 {"render_concurrency":3,"render_count":6}
info: GET /_ah/health 500 0ms
error: Health check failed > 1 {"render_concurrency":3,"render_count":6}
info: GET /_ah/health 500 1ms
error: Health check failed > 1 {"render_concurrency":3,"render_count":6}
info: GET /_ah/health 500 0ms
info: render details {"render_concurrency":2,"render_count":6,"render_crawler":"GoogleBot","render_duration_ms":2995,"render_id":"886cc4a4-2ba7-4941-9801-ca0ba9752e37","render_market":"de-at","render_status":200,"render_timeout":false,"render_url":"https://www.staging.env.mpb.com/de-at/produkt/dji-dl-pz-17-28mm-t30-asph?bust=5055","render_user_agent":"GoogleBot","render_varnish_cache":"miss"}
info: GET /render/https://www.staging.env.mpb.com/de-at/produkt/dji-dl-pz-17-28mm-t30-asph?bust=5055 200 2995ms
info: render request {"render_concurrency":3,"render_count":7,"render_crawler":"GoogleBot","render_id":"2108f2d7-351e-4fee-99f1-b31d50576316","render_market":"Not Found","render_url":"https://www.staging.env.mpb.com/en-uk?ref=www.invitation.app?bust=7791","render_user_agent":"GoogleBot"}
error: Health check failed > 1 {"render_concurrency":3,"render_count":7}
info: GET /_ah/health 500 0ms
info: render details {"render_concurrency":2,"render_count":7,"render_crawler":"GoogleBot","render_duration_ms":3602,"render_id":"ce7ffd36-a626-41ea-addd-38998c46b84a","render_market":"en-us","render_status":200,"render_timeout":false,"render_url":"https://www.staging.env.mpb.com/en-us/product/zeiss-milvus-25mm-f-1-4-ze-canon-ef-fit/sku-2941122?utm_source=google&utm_medium=surfaces&utm_campaign=shopping%20feed&utm_content=free%20google%20shopping%20clicks?bust=8653","render_user_agent":"GoogleBot","render_varnish_cache":"miss"}
info: GET /render/https://www.staging.env.mpb.com/en-us/product/zeiss-milvus-25mm-f-1-4-ze-canon-ef-fit/sku-2941122?utm_source=google&utm_medium=surfaces&utm_campaign=shopping%20feed&utm_content=free%20google%20shopping%20clicks?bust=8653 200 3602ms
info: render request {"render_concurrency":3,"render_count":8,"render_crawler":"GoogleBot","render_id":"b2801fb6-4b1e-451d-9133-38df6005f019","render_market":"de-de","render_url":"https://www.staging.env.mpb.com/de-de/produkt/sony-alpha-a7s-ii/sku-2955291?bust=6024","render_user_agent":"GoogleBot"}
info: render details {"render_concurrency":2,"render_count":8,"render_crawler":"GoogleBot","render_duration_ms":5514,"render_id":"ce989ce5-e736-4d5e-9206-74302fe74e13","render_market":"en-uk","render_status":200,"render_timeout":false,"render_url":"https://www.staging.env.mpb.com/en-uk/product/canon-powershot-g9?bust=7119","render_user_agent":"GoogleBot","render_varnish_cache":"miss"}
info: GET /render/https://www.staging.env.mpb.com/en-uk/product/canon-powershot-g9?bust=7119 200 5517ms
error: Health check failed > 1 {"render_concurrency":2,"render_count":8}
info: GET /_ah/health 500 1ms
error: Health check failed > 1 {"render_concurrency":2,"render_count":8}
info: GET /_ah/health 500 1ms
info: render details {"render_concurrency":1,"render_count":8,"render_crawler":"GoogleBot","render_duration_ms":2491,"render_id":"2108f2d7-351e-4fee-99f1-b31d50576316","render_market":"Not Found","render_status":200,"render_timeout":false,"render_url":"https://www.staging.env.mpb.com/en-uk?ref=www.invitation.app?bust=7791","render_user_agent":"GoogleBot","render_varnish_cache":"miss"}
info: GET /render/https://www.staging.env.mpb.com/en-uk?ref=www.invitation.app?bust=7791 200 2492ms
info: Health check passed <= 1 {"render_concurrency":1,"render_count":8}
info: GET /_ah/health 200 1ms
info: Health check passed <= 1 {"render_concurrency":1,"render_count":8}
info: GET /_ah/health 200 1ms
info: render details {"render_concurrency":0,"render_count":8,"render_crawler":"GoogleBot","render_duration_ms":3533,"render_id":"b2801fb6-4b1e-451d-9133-38df6005f019","render_market":"de-de","render_status":200,"render_timeout":false,"render_url":"https://www.staging.env.mpb.com/de-de/produkt/sony-alpha-a7s-ii/sku-2955291?bust=6024","render_user_agent":"GoogleBot","render_varnish_cache":"miss"}
info: GET /render/https://www.staging.env.mpb.com/de-de/produkt/sony-alpha-a7s-ii/sku-2955291?bust=6024 200 3534ms
info: Health check passed <= 1 {"render_concurrency":0,"render_count":8}
info: GET /_ah/health 200 1ms
```

**Note**: This also fixes some comments from the previous PR @JCorpe26 