### PR TITLE
add cooldown interval

### DIFF
--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -20,7 +20,9 @@ const marketRegex = /https:\/\/.*?\/(.*?)\//
 const concurrencyKillCount = Number(process.env.CONCURRENCY_KILL_COUNT) || 5;
 
 // 60s based on 10s healthcheck interval
-let cooldownCount = Number(process.env.COOLDOWN_COUNT) || 5;
+const cooldownCount = Number(process.env.COOLDOWN_COUNT) || 5;
+
+let cooldown = 0;
 
 /**
  * Rendertron rendering service. This runs the server which routes rendering
@@ -152,15 +154,23 @@ export class Rendertron {
   async handleHealthRequest(ctx: Koa.Context) {
     const { concurrency, count } = counter.getCounts()
 
-    if (concurrency <= concurrencyKillCount && cooldownCount === 0) {
-      logger.info(`Health check passed ${concurrencyKillCount} : ${cooldownCount}`, { render_concurrency: concurrency, render_count: count })
+    if (concurrency < concurrencyKillCount && cooldown === 0) {
+      logger.info(`Health check passed <= ${concurrencyKillCount}`, { render_concurrency: concurrency, render_count: count })
       ctx.status = 200;
       ctx.body = "OK";
       return;
     }
 
-    logger.error(`Health check failed ${concurrencyKillCount} : ${cooldownCount}`, { render_concurrency: concurrency, render_count: count })
-    cooldownCount--;
+    if (concurrency < concurrencyKillCount && cooldown > 0) {
+      logger.error(`Health check failed due to cooldown interval:  ${cooldown}`, { render_concurrency: concurrency, render_count: count })
+      cooldown--;
+      ctx.status = 500;
+      ctx.body = "ERROR";
+      return
+    }
+
+    logger.error(`Health check failed > ${concurrencyKillCount}`, { render_concurrency: concurrency, render_count: count })
+    cooldown = cooldownCount;
     ctx.status = 500;
     ctx.body = "ERROR";
   }


### PR DESCRIPTION
This change adds a cool down interval such that once a heath check fails, even if the concurrency count has gone down below the threshold it keeps the pod returning a failed heath check for a longer time period.

Based on a ten second interval the default value of 5 will ensure that post the last failure we have 5 more failed heath checks prior to the pod being marked as healthy.

The variable is configurable and can be provided using the `COOLDOWN_COUNT` via the environment.

```
info: Health check passed <= 5 {"render_concurrency":0,"render_count":3}
info: GET /_ah/health 200 4ms
... lots of renders

error: Health check failed > 5 {"render_concurrency":8,"render_count":11}
info: GET /_ah/health 500 1ms

.. let renders finish

error: Health check failed due to cooldown interval:  5 {"render_concurrency":0,"render_count":23}
info: GET /_ah/health 500 1ms
error: Health check failed due to cooldown interval:  4 {"render_concurrency":0,"render_count":23}
info: GET /_ah/health 500 1ms
error: Health check failed due to cooldown interval:  3 {"render_concurrency":0,"render_count":23}
info: GET /_ah/health 500 0ms
error: Health check failed due to cooldown interval:  2 {"render_concurrency":0,"render_count":23}
info: GET /_ah/health 500 1ms
error: Health check failed due to cooldown interval:  1 {"render_concurrency":0,"render_count":23}
info: GET /_ah/health 500 0ms
info: Health check passed <= 5 {"render_concurrency":0,"render_count":23}
info: GET /_ah/health 200 0ms
info: render request {"render_concurrency":1,"render_count":24,"render_crawler":"GoogleBot","render_id":"61bd0681-9276-4afb-ae57-e9e4f373aa97","render_market":"en-us","render_url":"https://www.staging.env.mpb.com/en-us/product/canon-eos-600d?bust=8160","render_user_agent":"GoogleBot"}
info: render details {"render_concurrency":0,"render_count":24,"render_crawler":"GoogleBot","render_duration_ms":2727,"render_id":"61bd0681-9276-4afb-ae57-e9e4f373aa97","render_market":"en-us","render_status":200,"render_timeout":false,"render_url":"https://www.staging.env.mpb.com/en-us/product/canon-eos-600d?bust=8160","render_user_agent":"GoogleBot","render_varnish_cache":"miss"}
info: GET /render/https://www.staging.env.mpb.com/en-us/product/canon-eos-600d?bust=8160 200 2728ms
```
  